### PR TITLE
Display immediate icon color change on like/dislike of photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ npx webpack --watch
 guard
 ```
 
+To run tests:
+```
+# run all tests
+rails test:system
+
+# run a specific test file
+rails test test/system/likes_test.rb
+```
+
 To reset the database (drop, create, migrate, and seed in one command):
 ```
 bundle exec rails db:reset

--- a/app/views/api/likes/show.json.jbuilder
+++ b/app/views/api/likes/show.json.jbuilder
@@ -1,1 +1,4 @@
-json.extract! @like, :id, :user_id, :likable_id, :likable_type
+json.id          @like.id
+json.userId      @like.user_id
+json.likableId   @like.likable_id
+json.likableType @like.likable_type

--- a/frontend/reducers/photo_reducer.js
+++ b/frontend/reducers/photo_reducer.js
@@ -46,24 +46,40 @@ export const photoReducer = (state = defaultState, action) => {
 
     case RECEIVE_PHOTO_LIKE:
 
-      newState = merge({}, state);
-      const photo = newState.byId[action.photoLike.likableId];
-      photo.likesCount += 1;
-      photo.usersWhoLike.push(action.photoLike.userId);
-      photo.likedByCurrentUser = true;
+      const likePhotoId = action.photoLike.likableId;
+      const likedPhoto = state.byId[likePhotoId];
 
-      return newState;
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          [likePhotoId]: {
+            ...likedPhoto,
+            likesCount: likedPhoto.likesCount + 1,
+            usersWhoLike: [...likedPhoto.usersWhoLike, action.photoLike.userId],
+            likedByCurrentUser: true
+          }
+        }
+      };
 
 
     case REMOVE_PHOTO_LIKE:
 
-      newState = merge({}, state);
-      const anotherPhoto = newState.byId[action.photoLike.likableId];
-      anotherPhoto.likesCount -= 1;
-      anotherPhoto.usersWhoLike.splice(anotherPhoto.usersWhoLike.indexOf(action.photoLike.userId), 1)
-      anotherPhoto.usersWhoLike.push(action.photoLike.userId);
-      anotherPhoto.likedByCurrentUser = false;
-      return newState;
+      const unlikePhotoId = action.photoLike.likableId;
+      const unlikedPhoto = state.byId[unlikePhotoId];
+
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          [unlikePhotoId]: {
+            ...unlikedPhoto,
+            likesCount: unlikedPhoto.likesCount - 1,
+            usersWhoLike: unlikedPhoto.usersWhoLike.filter(id => id !== action.photoLike.userId),
+            likedByCurrentUser: false
+          }
+        }
+      };
 
     case RECEIVE_COMMENT:
 

--- a/test/controllers/api/likes_controller_test.rb
+++ b/test/controllers/api/likes_controller_test.rb
@@ -1,7 +1,99 @@
-require 'test_helper'
+require "test_helper"
 
 class Api::LikesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @user = users(:testuser)
+    @photo = photos(:photo_one)
+    @photo_with_like = photos(:photo_two)
+  end
+
+  # Helper method to simulate logged-in user
+  def login_as(user)
+    post "/api/session", params: { user: { username: user.username, password: "password" } }
+  end
+
+  test "should create like and return camelCase JSON" do
+    login_as(@user)
+
+    assert_difference("Like.count", 1) do
+      post "/api/photos/#{@photo.id}/like",
+           params: { like: { likable_id: @photo.id, likable_type: "Photo" } }
+    end
+
+    assert_response :success
+
+    # Parse JSON response and verify structure/values
+    json_response = JSON.parse(response.body)
+    assert_like_json_response(json_response, @user.id, @photo.id)
+  end
+
+  test "should destroy like and return camelCase JSON" do
+    login_as(@user)
+
+    # Photo_two already has a like from testuser (from fixtures)
+    assert_difference("Like.count", -1) do
+      delete "/api/photos/#{@photo_with_like.id}/like",
+             params: { like: { likable_id: @photo_with_like.id, likable_type: "Photo" } }
+    end
+
+    assert_response :success
+
+    # Parse JSON response and verify structure/values
+    json_response = JSON.parse(response.body)
+    assert_like_json_response(json_response, @user.id, @photo_with_like.id)
+  end
+
+  test "should not allow duplicate likes" do
+    login_as(@user)
+
+    # Create initial like
+    post "/api/photos/#{@photo.id}/like",
+         params: { like: { likable_id: @photo.id, likable_type: "Photo" } }
+
+    assert_response :success
+
+    # Try to create duplicate like
+    assert_no_difference("Like.count") do
+      post "/api/photos/#{@photo.id}/like",
+           params: { like: { likable_id: @photo.id, likable_type: "Photo" } }
+    end
+
+    assert_response 422
+  end
+
+  test "should require authentication to create like" do
+    # Don't login - test unauthenticated request
+    assert_no_difference("Like.count") do
+      post "/api/photos/#{@photo.id}/like",
+           params: { like: { likable_id: @photo.id, likable_type: "Photo" } }
+    end
+
+    # Should redirect to login or return error
+    assert_not_equal 200, response.status
+  end
+
+  test "should require authentication to destroy like" do
+    # Don't login - test unauthenticated request
+    assert_no_difference("Like.count") do
+      delete "/api/photos/#{@photo_with_like.id}/like",
+             params: { like: { likable_id: @photo_with_like.id, likable_type: "Photo" } }
+    end
+
+    # Should redirect to login or return error
+    assert_not_equal 200, response.status
+  end
+
+  private
+
+  def assert_like_json_response(json_response, expected_user_id, expected_likable_id, expected_likable_type = "Photo")
+    # Assert camelCase field names (not snake_case) so that jbuilder matches the photo jbuilder pattern
+    assert json_response.key?("userId"), "Response should have 'userId' field (camelCase)"
+    assert json_response.key?("likableId"), "Response should have 'likableId' field (camelCase)"
+    assert json_response.key?("likableType"), "Response should have 'likableType' field (camelCase)"
+
+    # Assert correct values
+    assert_equal expected_user_id, json_response["userId"]
+    assert_equal expected_likable_id, json_response["likableId"]
+    assert_equal expected_likable_type, json_response["likableType"]
+  end
 end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -4,8 +4,8 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+# one: {}
 # column: value
 #
-two: {}
+# two: {}
 # column: value

--- a/test/fixtures/follows.yml
+++ b/test/fixtures/follows.yml
@@ -4,8 +4,8 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+# one: {}
 # column: value
 #
-two: {}
+# two: {}
 # column: value

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,11 +1,4 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+existing_like:
+  user: testuser
+  likable: photo_two (Photo)
+  likable_type: Photo

--- a/test/fixtures/photos.yml
+++ b/test/fixtures/photos.yml
@@ -1,11 +1,11 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+photo_one:
+  photo_url: "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501199362/test-photo.jpg"
+  caption: "Test photo for likes"
+  location: "Test Location"
+  author: testuser
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+photo_two:
+  photo_url: "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501199362/test-photo-2.jpg"
+  caption: "Another test photo"
+  location: "Another Location"
+  author: another_user

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,13 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+testuser:
+  username: testuser
+  name: Test User
+  session_token: <%= SecureRandom.urlsafe_base64 %>
+  password_digest: <%= BCrypt::Password.create('password') %>
+  profile_img_url: "https://res.cloudinary.com/dckkkjkuz/image/upload/v1500953840/instagram-color-fade_pvpssi.png"
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+another_user:
+  username: anotheruser
+  name: Another User
+  session_token: <%= SecureRandom.urlsafe_base64 %>
+  password_digest: <%= BCrypt::Password.create('password') %>
+  profile_img_url: "https://res.cloudinary.com/dckkkjkuz/image/upload/v1500953840/instagram-color-fade_pvpssi.png"

--- a/test/system/likes_test.rb
+++ b/test/system/likes_test.rb
@@ -1,0 +1,87 @@
+require "application_system_test_case"
+
+class LikesTest < ApplicationSystemTestCase
+  test "liking a photo immediately shows red heart without refresh" do
+    # Login as test user
+    visit "/login"
+    fill_in "username", with: "testuser"
+    fill_in "password", with: "password"
+    click_button "Log in"
+
+    # Navigate to home page with photos
+    visit "/"
+
+    # Find the heart icon for photo_one (should be outline/black)
+    # Looking for the outline heart image
+    outline_heart_url = "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501188966/007-favorite_t5zsnu.png"
+    red_heart_url = "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501199362/011-hearts_c0p7ac.png"
+
+    # Wait for page to load and verify outline heart is present
+    assert_selector "img[src='#{outline_heart_url}']"
+
+    # Find the specific heart button and click it
+    heart_button = find("img[src='#{outline_heart_url}']", match: :first)
+    heart_button.click
+
+    # Immediately verify (without page refresh) that heart icon changed to red
+    assert_selector "img[src='#{red_heart_url}']", wait: 5
+  end
+
+  test "unliking a photo immediately shows outline heart without refresh" do
+    # Login as test user
+    visit "/login"
+    fill_in "username", with: "testuser"
+    fill_in "password", with: "password"
+    click_button "Log in"
+
+    # Navigate to home page
+    visit "/"
+
+    # photo_two has an existing like from testuser (from fixtures)
+    # So the red heart should already be visible
+    red_heart_url = "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501199362/011-hearts_c0p7ac.png"
+    outline_heart_url = "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501188966/007-favorite_t5zsnu.png"
+
+    # Find and verify red heart is present
+    assert_selector "img[src='#{red_heart_url}']"
+
+    # Click the red heart to unlike
+    heart_button = find("img[src='#{red_heart_url}']", match: :first)
+    heart_button.click
+
+    # Immediately verify (without page refresh) that heart icon changed back to outline
+    assert_selector "img[src='#{outline_heart_url}']", wait: 5
+  end
+
+  test "liking and unliking a photo in sequence works correctly" do
+    # Login as test user
+    visit "/login"
+    fill_in "username", with: "testuser"
+    fill_in "password", with: "password"
+    click_button "Log in"
+
+    # Navigate to home page
+    visit "/"
+
+    outline_heart_url = "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501188966/007-favorite_t5zsnu.png"
+    red_heart_url = "https://res.cloudinary.com/dckkkjkuz/image/upload/v1501199362/011-hearts_c0p7ac.png"
+
+    # Start with outline heart
+    heart_button = find("img[src='#{outline_heart_url}']", match: :first)
+
+    # Like the photo and assert that heart icon turns red
+    heart_button.click
+    assert_selector "img[src='#{red_heart_url}']", wait: 5
+
+    # Unlike the photo (click the red heart that just appeared)
+    # and assert that it turns back to outline hear icon
+    red_heart_button = find("img[src='#{red_heart_url}']", match: :first)
+    red_heart_button.click
+    assert_selector "img[src='#{outline_heart_url}']", wait: 5
+
+    # Like the photo and assert that heart icon turns red
+    outline_heart_button = find("img[src='#{outline_heart_url}']", match: :first)
+    outline_heart_button.click
+    assert_selector "img[src='#{red_heart_url}']", wait: 5
+  end
+end


### PR DESCRIPTION
Previously, a manual refresh of the browswer was required to display the color change of the heart icon (after user liked/disliked a photo). This was due to a mismatch of snakecase vs camelcase between backend and frontend, respectively. This problem was resolved by adding test coverage and ensuring that the likes jbuilder pattern matches the photo jbuilder pattern.

This PR also includes alignment of redux code to modern conventions.